### PR TITLE
Keep new settings out of the file older versions read

### DIFF
--- a/app/gui/Settings.cs
+++ b/app/gui/Settings.cs
@@ -7,15 +7,45 @@ using System.Windows.Forms;
 using System.Xml.Serialization;
 using System.IO;
 using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace TIFPDFCounter
 {
+    /// <summary>
+    /// Which library analyses TIFF files.
+    /// </summary>
+    public enum TiffEngine
+    {
+        LibTiff,
+        MuPdf
+    }
+
     public static class Settings
     {
         readonly static string appData = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "ProFile Counter");
-        readonly static string settingsFilename = "UserSettings.xml";
-        readonly static string settingsFile = Path.Combine(appData, settingsFilename);
-        
+
+        /// <summary>
+        /// The settings file as version 3.3 and earlier understood it.
+        /// <para>
+        /// Those versions treat an unrecognised element as a hard error, discard every
+        /// setting, and then overwrite the file with defaults when the window closes --
+        /// so a user who installs an older build after a newer one loses their page
+        /// sizes permanently. This file is therefore frozen at the 3.3 schema: new
+        /// settings are marked [XmlIgnore] and live only in <see cref="preferencesFile"/>.
+        /// It is still written on every save so an older build sees current values for
+        /// the settings it does understand.
+        /// </para>
+        /// </summary>
+        readonly static string legacyFile = Path.Combine(appData, "UserSettings.xml");
+
+        /// <summary>
+        /// The settings file from 3.4 onwards, holding every setting. JSON rather than
+        /// XmlSerializer because it ignores properties it does not recognise, so a file
+        /// written by a future version stays readable here.
+        /// </summary>
+        readonly static string preferencesFile = Path.Combine(appData, "Preferences.json");
+
         public static UserSettings Current { get; private set; }
 
         static Settings()
@@ -25,38 +55,138 @@ namespace TIFPDFCounter
 
         public static void Load()
         {
+            var fromPreferences = LoadPreferences();
+            var fromLegacy = LoadLegacy();
+
+            if (fromPreferences == null && fromLegacy == null)
+            {
+                Current = DefaultUserSettings;
+                Save();
+                return;
+            }
+
+            if (fromPreferences == null)
+            {
+                // First run of 3.4 or later: carry the older file's values forward.
+                Current = fromLegacy;
+                Save();
+                return;
+            }
+
+            if (fromLegacy == null)
+            {
+                Current = fromPreferences;
+                return;
+            }
+
+            // Both exist. Normally Preferences.json is the newer of the two, but a user
+            // can run an older build in between, which writes only the legacy file. Take
+            // whichever was written last so those edits are not silently discarded.
+            if (File.GetLastWriteTimeUtc(legacyFile) > File.GetLastWriteTimeUtc(preferencesFile))
+            {
+                // Settings the older build cannot represent are not in its file; keep the
+                // values we already hold rather than resetting them to defaults.
+                fromLegacy.TiffEngine = fromPreferences.TiffEngine;
+                Current = fromLegacy;
+                Save();
+            }
+            else
+            {
+                Current = fromPreferences;
+            }
+        }
+
+        static UserSettings LoadPreferences()
+        {
+            if (!File.Exists(preferencesFile))
+                return null;
+
             try
             {
-                using (var stream = new FileStream(settingsFile, FileMode.Open))
+                var json = File.ReadAllText(preferencesFile);
+                var loaded = JsonConvert.DeserializeObject<UserSettings>(json);
+                return loaded ?? throw new Exception("Preferences file was empty.");
+            }
+            catch (Exception ex)
+            {
+                Quarantine(preferencesFile, ex);
+                return null;
+            }
+        }
+
+        static UserSettings LoadLegacy()
+        {
+            if (!File.Exists(legacyFile))
+                return null;
+
+            try
+            {
+                using (var stream = new FileStream(legacyFile, FileMode.Open, FileAccess.Read))
                 {
                     var xml = new XmlSerializer(typeof(UserSettings));
-                    
-                    xml.UnknownAttribute += (sender, args) =>
-                    {
-                        System.Diagnostics.Debug.Print("UnknownAttribute: " + args.ToString());
-                        throw new Exception("Unknown attribute: " + args.Attr.Name);
-                    };
-                    xml.UnknownElement += (sender, args) =>
-                    {
-                        System.Diagnostics.Debug.Print("UnknownElement: " + args.Element.Name);
-                        throw new Exception("Unknown element: " + args.Element.Name);
-                    };
 
-                    Current = xml.Deserialize(stream) as UserSettings;
+                    // Log unrecognised content rather than failing on it. Treating it as an
+                    // error is what made a newer settings file destroy an older build's
+                    // configuration; a setting we do not know about is not a reason to throw
+                    // away the ones we do.
+                    xml.UnknownAttribute += (sender, args) =>
+                        System.Diagnostics.Debug.Print("UnknownAttribute: " + args.Attr.Name);
+                    xml.UnknownElement += (sender, args) =>
+                        System.Diagnostics.Debug.Print("UnknownElement: " + args.Element.Name);
+
+                    return xml.Deserialize(stream) as UserSettings;
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                MessageBox.Show("Default settings are loaded.", "Defaults", MessageBoxButtons.OK, MessageBoxIcon.Information);
-                Current = DefaultUserSettings;
+                Quarantine(legacyFile, ex);
+                return null;
             }
+        }
+
+        /// <summary>
+        /// Moves a settings file we could not read aside instead of letting the next save
+        /// overwrite it. Without this a transient problem -- a half-written file, a disk
+        /// error -- silently costs the user every custom page size they had.
+        /// </summary>
+        static void Quarantine(string path, Exception ex)
+        {
+            System.Diagnostics.Debug.Print("Could not read " + path + ": " + ex.Message);
+            try
+            {
+                var bad = path + ".bad";
+                File.Delete(bad);
+                File.Move(path, bad);
+            }
+            catch { /* nothing further to try; do not block startup over it */ }
         }
 
         public static void Save()
         {
+            SavePreferences();
+            SaveLegacy();
+        }
+
+        static void SavePreferences()
+        {
             try
             {
-                using (var stream = new FileStream(settingsFile, FileMode.Create))
+                var json = JsonConvert.SerializeObject(Current, Formatting.Indented);
+                File.WriteAllText(preferencesFile, json);
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Written on every save purely so that an older build still sees current values.
+        /// Properties added after 3.3 are [XmlIgnore] and must stay that way -- adding one
+        /// here would make those versions discard the whole file.
+        /// </summary>
+        static void SaveLegacy()
+        {
+            try
+            {
+                using (var stream = new FileStream(legacyFile, FileMode.Create))
                 {
                     var xml = new XmlSerializer(typeof(UserSettings));
                     xml.Serialize(stream, Current);
@@ -79,6 +209,7 @@ namespace TIFPDFCounter
                 def.WindowLocation = new Point(0, 0);
                 def.WindowSize = new Size(640, 480);
                 def.WindowState = FormWindowState.Normal;
+                def.TiffEngine = TiffEngine.LibTiff;
                 def.ColorThreshold = 0.25m;
                 def.PerformColorAnalysis = true;
                 def.CheckForDuplicateFiles = true;
@@ -123,7 +254,22 @@ namespace TIFPDFCounter
             public Size WindowSize { get; set; }
             public FormWindowState WindowState { get; set; }
             /// <summary>
-            /// A number between 0 and 1 which represents how far away from gray a color can be before it is considered color. 
+            /// Which library analyses TIFF files. LibTIFF is markedly faster and uses a
+            /// fraction of the memory; MuPDF is kept as an escape hatch for files where
+            /// LibTIFF gives an unexpected answer.
+            /// <para>
+            /// [XmlIgnore] is required, not cosmetic: version 3.3 and earlier abort on any
+            /// element they do not recognise and then overwrite the file with defaults.
+            /// Every setting added after 3.3 must carry this attribute, so it appears in
+            /// Preferences.json only.
+            /// </para>
+            /// </summary>
+            [XmlIgnore]
+            [JsonConverter(typeof(StringEnumConverter))]
+            public TiffEngine TiffEngine { get; set; }
+
+            /// <summary>
+            /// A number between 0 and 1 which represents how far away from gray a color can be before it is considered color.
             /// 0.02 is very strict. 0.25 allows for some variation (like in JPEG artifacts).
             /// </summary>
             public decimal ColorThreshold { get; set; }


### PR DESCRIPTION
Adding any element to `UserSettings.xml` permanently destroys the settings of
anyone who later installs 3.3 or earlier. This clears the way for new settings
without that consequence, and fixes two data-loss bugs found alongside it.

## The problem

Version 3.3 and earlier treat an unrecognised element as a hard error:

```csharp
xml.UnknownElement += (sender, args) => { throw new Exception(...); };
...
catch (Exception) {
    MessageBox.Show("Default settings are loaded.", ...);
    Current = DefaultUserSettings;
}
```

`MainForm` then calls `Settings.Save()` unconditionally when the window closes,
writing those defaults over the file. **One open-and-close is enough to lose
every custom page size**, and the dialog only says "Default settings are loaded".

Since 3.3 is already released and cannot be changed, the only way to keep it
working is to stop putting new settings in that file.

## The scheme

| File | Contents | Written | Read by |
| --- | --- | --- | --- |
| `UserSettings.xml` | 3.3 schema only | every save | 3.3 and later |
| `Preferences.json` | everything | every save | 3.4+ |

New properties are marked `[XmlIgnore]`, so `XmlSerializer` never writes them
while Newtonsoft includes them. **The attribute is load bearing rather than
cosmetic** — a property added without it would make older versions discard the
whole file — and both the property and `SaveLegacy()` say so. JSON also ignores
properties it does not recognise, so a file written by a future version stays
readable here.

**Both files are written on every save**, so an older build continues to see
current values for the settings it understands.

**On load, whichever file was written last wins.** A user can run an older build
in between, which updates only the legacy file; those edits should not be
silently discarded. Settings the older build cannot represent are carried over
from the newer file rather than reset:

```csharp
if (File.GetLastWriteTimeUtc(legacyFile) > File.GetLastWriteTimeUtc(preferencesFile))
{
    fromLegacy.TiffEngine = fromPreferences.TiffEngine;
    Current = fromLegacy;
    Save();
}
```

The first run of 3.4 finds no `Preferences.json`, so it carries the legacy file's
values forward and writes both.

## Two data-loss bugs fixed alongside

**An unreadable settings file is now moved aside as `.bad` rather than
overwritten.** Previously a failed load set `Current` to defaults and the next
window close wrote them over the file — so a half-written file or a transient
disk error cost the user every custom page size, with nothing left to recover.

**Unrecognised XML is logged rather than thrown.** `XmlSerializer` ignores unknown
elements by default; failing on them was a deliberate choice, and it is the
mechanism behind the problem above. Ignoring them protects every future
transition even if the two-file split is later abandoned.

The `MessageBox` is gone from the load path — it fired on every failure and
described a reset as though it were routine. Worth deciding whether a message
should appear at all, and if so one that mentions the preserved `.bad` file.

## For reviewers

**Orientation.** One file changes: `app/gui/Settings.cs`. The relevant call sites
elsewhere are unchanged and worth reading alongside it:

- `MainForm.cs:284` — `Settings.Save()` on window close. This is what turns a
  failed load into permanent data loss, and it is why quarantining matters.
- `MainForm.cs:289` — `Settings.Load()` on startup.
- `SettingsWindow.cs:51` — `Settings.Save()` when the user clicks OK.
- `installer/script.iss` `[UninstallDelete]` — removes
  `{localappdata}\ProFile Counter` entirely. Relevant because it bounds the
  problem: an uninstall/reinstall is a clean slate, whereas installing *over* an
  existing version does not run the uninstaller, and that is the path this PR
  addresses.

**`TiffEngine` is deliberately unused here.** It is the first setting that would
have triggered the bug, and it exists so the scheme has a concrete example to
review. The GUI control and the analyzer plumbing arrive with the LibTIFF work on
a separate branch. If you would rather this PR carried no unused setting, it can
be removed and the mechanism reviewed on its own — but then nothing demonstrates
the `[XmlIgnore]` requirement.

**The invariant that must survive.** Every property added after 3.3 must carry
`[XmlIgnore]`. Miss it once and 3.3 and earlier discard the user's entire
configuration. There is currently nothing enforcing this beyond comments on the
property and on `SaveLegacy()` — the repository has no test project. If you can
think of a cheap enforcement mechanism, it is worth adding.

**Specific things to scrutinise**, roughly in order of how likely I think they are
to be wrong:

1. **`Point` / `Size` / `FormWindowState` round-tripping through Newtonsoft.**
   These previously went through `XmlSerializer`. `Point` and `Size` expose
   settable `X`/`Y`/`Width`/`Height` so they should be fine, but window geometry
   silently resetting is exactly what slips past a code read. Untested.
2. **The timestamp comparison.** `File.GetLastWriteTimeUtc(legacy) > GetLastWriteTimeUtc(preferences)`
   decides which file wins. Both are written in the same `Save()`, so under normal
   use they are equal or preferences is later, and preferences wins. Consider:
   filesystem timestamp granularity, a user changing the system clock, and files
   restored from a backup with preserved timestamps.
3. **Quarantine is not atomic.** `File.Delete(bad)` then `File.Move(path, bad)`.
   A crash between them loses the file. A second corruption also overwrites the
   first `.bad`, discarding the earlier evidence — arguably a timestamped name
   would be better.
4. **Two instances running at once.** Last writer wins, with no locking. This is
   pre-existing behaviour, not introduced here, but the two-file scheme doubles
   the window in which the pair can disagree.
5. **The migration writes on load.** First run of 3.4 calls `Save()` from inside
   `Load()`. Check that is acceptable on a read-only profile or a locked file —
   `Save()` swallows exceptions, so it should degrade quietly, but the reasoning
   is worth confirming.
6. **Removing the `MessageBox`.** The user now gets no indication that their
   settings were reset. That is deliberate — the old dialog understated what had
   happened — but it is a UX decision, not purely a bug fix, and you may want a
   better message rather than none.

## Not yet verified

`Point`, `Size` and `FormWindowState` now round-trip through Newtonsoft rather
than `XmlSerializer`. They should be fine, but window geometry silently resetting
is exactly the sort of thing that slips through — worth launching the GUI, moving
and resizing the window, then reopening.

The downgrade path is worth exercising for real: run 3.4, confirm both files
appear, install 3.3 over the top, and check the page sizes survive.

Note the uninstaller removes `{localappdata}\ProFile Counter` entirely, so an
uninstall/reinstall cycle is a clean slate regardless. Installing *over* an
existing version does not run the uninstaller, which is the path this addresses.
